### PR TITLE
feat: add status page list and info commands

### DIFF
--- a/docs/openstatus-docs.md
+++ b/docs/openstatus-docs.md
@@ -2,17 +2,26 @@
 
 ## CLI interface - openstatus
 
-OpenStatus is a command line interface for managing your monitors and triggering your synthetics tests.   Please report any issues at https://github.com/openstatusHQ/cli/issues/new.
+OpenStatus CLI lets you manage your status pages and uptime monitors from the command line. Report and track incidents, define monitors as code, and run on-demand checks.  Get started:   openstatus login                Save your API token   openstatus status-report create Report an incident   openstatus status-report list   View active incidents   openstatus monitors apply       Sync monitors from config   openstatus monitors list        List your monitors   openstatus run                  Run synthetic tests  https://docs.openstatus.dev  |  https://github.com/openstatusHQ/cli/issues/new.
 
-This is OpenStatus Command Line Interface, the OpenStatus.dev CLI.
+Manage status pages, monitors, and incidents from the terminal.
 
 Usage:
 
 ```bash
-$ openstatus [COMMAND] [COMMAND FLAGS] [ARGUMENTS...]
+$ openstatus [GLOBAL FLAGS] [COMMAND] [COMMAND FLAGS] [ARGUMENTS...]
 ```
 
-### `monitors` command
+Global flags:
+
+| Name             | Description               | Default value | Environment variables |
+|------------------|---------------------------|:-------------:|:---------------------:|
+| `--json`         | Output results as JSON    |    `false`    |        *none*         |
+| `--no-color`     | Disable colored output    |    `false`    |        *none*         |
+| `--quiet` (`-q`) | Suppress non-error output |    `false`    |        *none*         |
+| `--debug`        | Enable debug output       |    `false`    |        *none*         |
+
+### `monitors` command (aliases: `m`)
 
 Manage your monitors.
 
@@ -26,9 +35,11 @@ $ openstatus [GLOBAL FLAGS] monitors [ARGUMENTS...]
 
 Create or update monitors.
 
-> openstatus monitors apply [options]
+> openstatus monitors apply
+>   openstatus monitors apply --config custom.yaml -y
+>   openstatus monitors apply --dry-run
 
-Creates or updates monitors according to the OpenStatus configuration file.
+Creates or updates monitors according to the OpenStatus configuration file. Compares your openstatus.yaml with the current state and applies changes.
 
 Usage:
 
@@ -43,12 +54,14 @@ The following flags are supported:
 | `--config="…"` (`-c`)       | The configuration file containing monitor information | `openstatus.yaml` |         *none*         |
 | `--access-token="…"` (`-t`) | OpenStatus API Access Token                           |                   | `OPENSTATUS_API_TOKEN` |
 | `--auto-accept` (`-y`)      | Automatically accept the prompt                       |      `false`      |         *none*         |
+| `--dry-run` (`-n`)          | Show what would be changed without applying           |      `false`      |         *none*         |
 
 ### `monitors create` subcommand
 
-Create monitors (beta).
+Create monitors.
 
-> openstatus monitors create [options]
+> openstatus monitors create
+>   openstatus monitors create --config custom.yaml -y
 
 Create the monitors defined in the openstatus.yaml file.
 
@@ -70,7 +83,8 @@ The following flags are supported:
 
 Delete a monitor.
 
-> openstatus monitors delete [MonitorID] [options]
+> openstatus monitors delete <MonitorID>
+>   openstatus monitors delete 12345 -y
 
 Usage:
 
@@ -89,7 +103,8 @@ The following flags are supported:
 
 Import all your monitors.
 
-> openstatus monitors import [options]
+> openstatus monitors import
+>   openstatus monitors import --output monitors.yaml
 
 Import all your monitors from your workspace to a YAML file; it will also create a lock file to manage your monitors with 'apply'.
 
@@ -110,9 +125,10 @@ The following flags are supported:
 
 Get a monitor information.
 
-> openstatus monitors info [MonitorID]
+> openstatus monitors info <MonitorID>
+>   openstatus monitors info 12345
 
-Fetch the monitor information. The monitor information includes details such as name, description, endpoint, method, frequency, locations, active status, public status, timeout, degraded after, and body. The body is truncated to 40 characters.
+Fetch the monitor information. The monitor information includes details such as name, description, endpoint, method, frequency, locations, active status, public status, timeout, degraded after, and body.
 
 Usage:
 
@@ -130,9 +146,10 @@ The following flags are supported:
 
 List all monitors.
 
-> openstatus monitors list [options]
+> openstatus monitors list
+>   openstatus monitors list --all
 
-List all monitors. The list shows all your monitors attached to your workspace. It displays the ID, name, and URL of each monitor.
+List all monitors. The list shows all your monitors attached to your workspace. It displays the ID, name, URL, and kind of each monitor.
 
 Usage:
 
@@ -151,7 +168,8 @@ The following flags are supported:
 
 Trigger a monitor execution.
 
-> openstatus monitors trigger [MonitorId] [options]
+> openstatus monitors trigger <MonitorID>
+>   openstatus monitors trigger 12345
 
 Trigger a monitor execution on demand. This command allows you to launch your tests on demand.
 
@@ -181,7 +199,8 @@ $ openstatus [GLOBAL FLAGS] status-report [ARGUMENTS...]
 
 List all status reports.
 
-> openstatus status-report list [options]
+> openstatus status-report list
+>   openstatus status-report list --status investigating --limit 10
 
 Usage:
 
@@ -202,6 +221,7 @@ The following flags are supported:
 Get status report details.
 
 > openstatus status-report info <ReportID>
+>   openstatus status-report info 12345
 
 Usage:
 
@@ -265,6 +285,7 @@ The following flags are supported:
 Delete a status report.
 
 > openstatus status-report delete <ReportID>
+>   openstatus status-report delete 12345 -y
 
 Usage:
 
@@ -301,13 +322,63 @@ The following flags are supported:
 | `--date="…"`                | Date for the update (RFC 3339 format, defaults to now)       |               |         *none*         |
 | `--notify`                  | Notify subscribers about this update                         |    `false`    |         *none*         |
 
+### `status-page` command (aliases: `sp`)
+
+Manage status pages.
+
+Usage:
+
+```bash
+$ openstatus [GLOBAL FLAGS] status-page [ARGUMENTS...]
+```
+
+### `status-page list` subcommand
+
+List all status pages.
+
+> openstatus status-page list
+>   openstatus status-page list --limit 10
+
+Usage:
+
+```bash
+$ openstatus [GLOBAL FLAGS] status-page list [COMMAND FLAGS] [ARGUMENTS...]
+```
+
+The following flags are supported:
+
+| Name                        | Description                               | Default value |  Environment variables |
+|-----------------------------|-------------------------------------------|:-------------:|:----------------------:|
+| `--access-token="…"` (`-t`) | OpenStatus API Access Token               |               | `OPENSTATUS_API_TOKEN` |
+| `--limit="…"`               | Maximum number of pages to return (1-100) |      `0`      |         *none*         |
+
+### `status-page info` subcommand
+
+Get status page details.
+
+> openstatus status-page info <PageID>
+>   openstatus status-page info 12345
+
+Usage:
+
+```bash
+$ openstatus [GLOBAL FLAGS] status-page info [COMMAND FLAGS] [ARGUMENTS...]
+```
+
+The following flags are supported:
+
+| Name                        | Description                 | Default value |  Environment variables |
+|-----------------------------|-----------------------------|:-------------:|:----------------------:|
+| `--access-token="…"` (`-t`) | OpenStatus API Access Token |               | `OPENSTATUS_API_TOKEN` |
+
 ### `run` command (aliases: `r`)
 
-Run your synthetics tests.
+Run your uptime tests.
 
-> openstatus run [options]
+> openstatus run
+>   openstatus run --config custom-config.yaml
 
-Run the synthetic tests defined in the config.openstatus.yaml. The config file should be in the following format:  tests:   ids:      - monitor-id-1      - monitor-id-2.
+Run the uptime tests defined in the config.openstatus.yaml. The config file should be in the following format:  tests:   ids:      - monitor-id-1      - monitor-id-2.
 
 Usage:
 
@@ -326,9 +397,9 @@ The following flags are supported:
 
 Get your workspace information.
 
-> openstatus whoami [options]
+> openstatus whoami
 
-Get your current workspace information, display the workspace name, slug, and plan.
+Get your current workspace information. Displays the workspace name, slug, and plan.
 
 Usage:
 
@@ -341,3 +412,29 @@ The following flags are supported:
 | Name                        | Description                 | Default value |  Environment variables |
 |-----------------------------|-----------------------------|:-------------:|:----------------------:|
 | `--access-token="…"` (`-t`) | OpenStatus API Access Token |               | `OPENSTATUS_API_TOKEN` |
+
+### `login` command
+
+Save your API token.
+
+> openstatus login
+
+Saves your OpenStatus API token for use in subsequent commands. Get your API token from the OpenStatus dashboard.
+
+Usage:
+
+```bash
+$ openstatus [GLOBAL FLAGS] login [ARGUMENTS...]
+```
+
+### `logout` command
+
+Remove saved API token.
+
+> openstatus logout
+
+Usage:
+
+```bash
+$ openstatus [GLOBAL FLAGS] logout [ARGUMENTS...]
+```

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openstatusHQ/cli/internal/login"
 	"github.com/openstatusHQ/cli/internal/monitors"
 	"github.com/openstatusHQ/cli/internal/run"
+	"github.com/openstatusHQ/cli/internal/statuspage"
 	"github.com/openstatusHQ/cli/internal/statusreport"
 	"github.com/openstatusHQ/cli/internal/whoami"
 	"github.com/urfave/cli/v3"
@@ -64,6 +65,7 @@ https://docs.openstatus.dev  |  https://github.com/openstatusHQ/cli/issues/new`,
 		Commands: []*cli.Command{
 			monitors.MonitorsCmd(),
 			statusreport.StatusReportCmd(),
+			statuspage.StatusPageCmd(),
 			run.RunCmd(),
 			whoami.WhoamiCmd(),
 			login.LoginCmd(),

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -32,13 +32,14 @@ func Test_NewApp(t *testing.T) {
 	t.Run("Has expected commands", func(t *testing.T) {
 		app := cmd.NewApp()
 
-		if len(app.Commands) != 6 {
-			t.Errorf("Expected 6 commands, got %d", len(app.Commands))
+		if len(app.Commands) != 7 {
+			t.Errorf("Expected 7 commands, got %d", len(app.Commands))
 		}
 
 		expectedCommands := map[string]bool{
 			"monitors":      false,
 			"status-report": false,
+			"status-page":   false,
 			"run":           false,
 			"whoami":        false,
 			"login":         false,

--- a/internal/statuspage/statuspage.go
+++ b/internal/statuspage/statuspage.go
@@ -1,0 +1,78 @@
+package statuspage
+
+import (
+	"net/http"
+
+	status_pagev1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_page/v1"
+	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/status_page/v1/status_pagev1connect"
+	"connectrpc.com/connect"
+	"github.com/openstatusHQ/cli/internal/api"
+	"github.com/urfave/cli/v3"
+)
+
+func NewStatusPageClient(apiKey string) status_pagev1connect.StatusPageServiceClient {
+	return status_pagev1connect.NewStatusPageServiceClient(
+		api.DefaultHTTPClient,
+		api.ConnectBaseURL,
+		connect.WithInterceptors(api.NewAuthInterceptor(apiKey)),
+		connect.WithProtoJSON(),
+	)
+}
+
+func NewStatusPageClientWithHTTPClient(httpClient *http.Client, apiKey string) status_pagev1connect.StatusPageServiceClient {
+	return status_pagev1connect.NewStatusPageServiceClient(
+		httpClient,
+		api.ConnectBaseURL,
+		connect.WithInterceptors(api.NewAuthInterceptor(apiKey)),
+		connect.WithProtoJSON(),
+	)
+}
+
+func accessTypeToString(a status_pagev1.PageAccessType) string {
+	switch a {
+	case status_pagev1.PageAccessType_PAGE_ACCESS_TYPE_PUBLIC:
+		return "public"
+	case status_pagev1.PageAccessType_PAGE_ACCESS_TYPE_PASSWORD_PROTECTED:
+		return "password-protected"
+	case status_pagev1.PageAccessType_PAGE_ACCESS_TYPE_AUTHENTICATED:
+		return "authenticated"
+	default:
+		return "unknown"
+	}
+}
+
+func themeToString(t status_pagev1.PageTheme) string {
+	switch t {
+	case status_pagev1.PageTheme_PAGE_THEME_SYSTEM:
+		return "system"
+	case status_pagev1.PageTheme_PAGE_THEME_LIGHT:
+		return "light"
+	case status_pagev1.PageTheme_PAGE_THEME_DARK:
+		return "dark"
+	default:
+		return "unknown"
+	}
+}
+
+func componentTypeToString(t status_pagev1.PageComponentType) string {
+	switch t {
+	case status_pagev1.PageComponentType_PAGE_COMPONENT_TYPE_MONITOR:
+		return "monitor"
+	case status_pagev1.PageComponentType_PAGE_COMPONENT_TYPE_STATIC:
+		return "static"
+	default:
+		return "unknown"
+	}
+}
+
+func StatusPageCmd() *cli.Command {
+	return &cli.Command{
+		Name:    "status-page",
+		Aliases: []string{"sp"},
+		Usage:   "Manage status pages",
+		Commands: []*cli.Command{
+			GetStatusPageListCmd(),
+			GetStatusPageInfoCmd(),
+		},
+	}
+}

--- a/internal/statuspage/statuspage_info.go
+++ b/internal/statuspage/statuspage_info.go
@@ -1,0 +1,229 @@
+package statuspage
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	status_pagev1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_page/v1"
+	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/status_page/v1/status_pagev1connect"
+	"github.com/fatih/color"
+	"github.com/logrusorgru/aurora/v4"
+	"github.com/olekukonko/tablewriter"
+	"github.com/olekukonko/tablewriter/renderer"
+	"github.com/olekukonko/tablewriter/tw"
+	"github.com/openstatusHQ/cli/internal/auth"
+	output "github.com/openstatusHQ/cli/internal/cli"
+	"github.com/rodaine/table"
+	"github.com/urfave/cli/v3"
+)
+
+type statusPageDetail struct {
+	ID          string                `json:"id"`
+	Title       string                `json:"title"`
+	Description string                `json:"description,omitempty"`
+	URL         string                `json:"url"`
+	Published   bool                  `json:"published"`
+	AccessType  string                `json:"access_type"`
+	Theme       string                `json:"theme"`
+	HomepageURL string                `json:"homepage_url,omitempty"`
+	ContactURL  string                `json:"contact_url,omitempty"`
+	Components  []statusPageComponent `json:"components,omitempty"`
+}
+
+type statusPageComponent struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Type        string `json:"type"`
+	Group       string `json:"group,omitempty"`
+	Order       int32  `json:"order"`
+}
+
+func buildComponents(components []*status_pagev1.PageComponent, groups []*status_pagev1.PageComponentGroup) []statusPageComponent {
+	groupMap := make(map[string]string, len(groups))
+	for _, g := range groups {
+		groupMap[g.GetId()] = g.GetName()
+	}
+
+	result := make([]statusPageComponent, 0, len(components))
+	for _, c := range components {
+		comp := statusPageComponent{
+			ID:          c.GetId(),
+			Name:        c.GetName(),
+			Description: c.GetDescription(),
+			Type:        componentTypeToString(c.GetType()),
+			Order:       c.GetOrder(),
+		}
+		if gid := c.GetGroupId(); gid != "" {
+			comp.Group = groupMap[gid]
+		}
+		result = append(result, comp)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Group != result[j].Group {
+			if result[i].Group == "" {
+				return false
+			}
+			if result[j].Group == "" {
+				return true
+			}
+			return result[i].Group < result[j].Group
+		}
+		return result[i].Order < result[j].Order
+	})
+
+	return result
+}
+
+func GetStatusPageInfo(ctx context.Context, client status_pagev1connect.StatusPageServiceClient, pageId string, s *output.Spinner) error {
+	if pageId == "" {
+		output.StopSpinner(s)
+		fmt.Fprintln(os.Stderr, "Usage: openstatus status-page info <page-id>")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Example: openstatus status-page info 12345")
+		return fmt.Errorf("page ID is required")
+	}
+
+	req := &status_pagev1.GetStatusPageContentRequest{}
+	req.SetId(pageId)
+	resp, err := client.GetStatusPageContent(ctx, req)
+	output.StopSpinner(s)
+	if err != nil {
+		return output.FormatError(err, "status-page", pageId)
+	}
+
+	page := resp.GetStatusPage()
+	comps := buildComponents(resp.GetComponents(), resp.GetGroups())
+
+	pageURL := "https://" + page.GetSlug() + ".openstatus.dev"
+	if cd := page.GetCustomDomain(); cd != "" {
+		cd = strings.TrimPrefix(strings.TrimPrefix(cd, "https://"), "http://")
+		pageURL = "https://" + cd
+	}
+
+	if output.IsJSONOutput() {
+		detail := statusPageDetail{
+			ID:          page.GetId(),
+			Title:       page.GetTitle(),
+			Description: page.GetDescription(),
+			URL:         pageURL,
+			Published:   page.GetPublished(),
+			AccessType:  accessTypeToString(page.GetAccessType()),
+			Theme:       themeToString(page.GetTheme()),
+			HomepageURL: page.GetHomepageUrl(),
+			ContactURL:  page.GetContactUrl(),
+			Components:  comps,
+		}
+		return output.PrintJSON(detail)
+	}
+
+	fmt.Println(aurora.Bold("Status Page:"))
+	tbl := tablewriter.NewTable(os.Stdout,
+		tablewriter.WithRenderer(renderer.NewBlueprint()),
+		tablewriter.WithRendition(tw.Rendition{
+			Symbols: tw.NewSymbolCustom("custom").WithColumn("="),
+			Borders: tw.Border{
+				Top:    tw.Off,
+				Left:   tw.Off,
+				Right:  tw.Off,
+				Bottom: tw.Off,
+			},
+			Settings: tw.Settings{
+				Lines: tw.Lines{
+					ShowHeaderLine: tw.Off,
+					ShowFooterLine: tw.On,
+				},
+				Separators: tw.Separators{
+					BetweenRows:    tw.Off,
+					BetweenColumns: tw.On,
+				},
+			},
+		}),
+		tablewriter.WithRowAlignment(tw.AlignLeft),
+		tablewriter.WithHeaderAlignment(tw.AlignLeft),
+	)
+
+	data := [][]string{
+		{"ID", page.GetId()},
+		{"Title", page.GetTitle()},
+		{"URL", pageURL},
+		{"Published", strconv.FormatBool(page.GetPublished())},
+	}
+
+	if page.GetDescription() != "" {
+		data = append(data, []string{"Description", page.GetDescription()})
+	}
+
+	data = append(data, []string{"Access Type", accessTypeToString(page.GetAccessType())})
+	data = append(data, []string{"Theme", themeToString(page.GetTheme())})
+
+	if page.GetHomepageUrl() != "" {
+		data = append(data, []string{"Homepage URL", page.GetHomepageUrl()})
+	}
+	if page.GetContactUrl() != "" {
+		data = append(data, []string{"Contact URL", page.GetContactUrl()})
+	}
+
+	tbl.Bulk(data)
+	tbl.Render()
+
+	if len(comps) > 0 {
+		fmt.Println(aurora.Bold("\nComponents:"))
+
+		headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
+		columnFmt := color.New(color.FgYellow).SprintfFunc()
+
+		compTbl := table.New("Name", "Type", "Group")
+		compTbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
+
+		for _, c := range comps {
+			compTbl.AddRow(c.Name, c.Type, c.Group)
+		}
+
+		compTbl.Print()
+	}
+
+	return nil
+}
+
+func GetStatusPageInfoWithHTTPClient(ctx context.Context, httpClient *http.Client, apiKey string, pageId string) error {
+	client := NewStatusPageClientWithHTTPClient(httpClient, apiKey)
+	return GetStatusPageInfo(ctx, client, pageId, nil)
+}
+
+func GetStatusPageInfoCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "info",
+		Usage: "Get status page details",
+		UsageText: `openstatus status-page info <PageID>
+  openstatus status-page info 12345`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "access-token",
+				Usage:   "OpenStatus API Access Token",
+				Aliases: []string{"t"},
+				Sources: cli.EnvVars("OPENSTATUS_API_TOKEN"),
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			apiKey, err := auth.ResolveAccessToken(cmd)
+			if err != nil {
+				return cli.Exit(err.Error(), 1)
+			}
+			pageId := cmd.Args().Get(0)
+			s := output.StartSpinner("Fetching status page...")
+			client := NewStatusPageClient(apiKey)
+			err = GetStatusPageInfo(ctx, client, pageId, s)
+			if err != nil {
+				return cli.Exit(err.Error(), 1)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/statuspage/statuspage_info_test.go
+++ b/internal/statuspage/statuspage_info_test.go
@@ -1,0 +1,146 @@
+package statuspage_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/openstatusHQ/cli/internal/statuspage"
+)
+
+func Test_GetStatusPageInfo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Successfully returns page with components", func(t *testing.T) {
+		body := `{"statusPage":{"id":"1","title":"My Page","description":"Main status page","slug":"my-page","published":true,"accessType":"PAGE_ACCESS_TYPE_PUBLIC","theme":"PAGE_THEME_SYSTEM","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"},"components":[{"id":"c1","pageId":"1","name":"API","type":"PAGE_COMPONENT_TYPE_MONITOR","order":1},{"id":"c2","pageId":"1","name":"CDN","type":"PAGE_COMPONENT_TYPE_STATIC","groupId":"g1","order":1,"groupOrder":1}],"groups":[{"id":"g1","pageId":"1","name":"Infrastructure"}]}`
+		r := io.NopCloser(bytes.NewReader([]byte(body)))
+
+		interceptor := &interceptorHTTPClient{
+			f: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       r,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+				}, nil
+			},
+		}
+
+		err := statuspage.GetStatusPageInfoWithHTTPClient(context.Background(), interceptor.GetHTTPClient(), "test-token", "1")
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("Successfully returns page without components", func(t *testing.T) {
+		body := `{"statusPage":{"id":"2","title":"Empty Page","slug":"empty","published":false,"accessType":"PAGE_ACCESS_TYPE_PUBLIC","theme":"PAGE_THEME_LIGHT","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"},"components":[],"groups":[]}`
+		r := io.NopCloser(bytes.NewReader([]byte(body)))
+
+		interceptor := &interceptorHTTPClient{
+			f: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       r,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+				}, nil
+			},
+		}
+
+		err := statuspage.GetStatusPageInfoWithHTTPClient(context.Background(), interceptor.GetHTTPClient(), "test-token", "2")
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("Missing page ID returns error", func(t *testing.T) {
+		interceptor := &interceptorHTTPClient{
+			f: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+				}, nil
+			},
+		}
+
+		err := statuspage.GetStatusPageInfoWithHTTPClient(context.Background(), interceptor.GetHTTPClient(), "test-token", "")
+		if err == nil {
+			t.Error("Expected error for empty page ID, got nil")
+		}
+		if err.Error() != "page ID is required" {
+			t.Errorf("Expected 'page ID is required' error, got %v", err)
+		}
+	})
+
+	t.Run("Uses custom domain as URL", func(t *testing.T) {
+		body := `{"statusPage":{"id":"3","title":"Custom Page","slug":"custom","published":true,"customDomain":"status.example.com","accessType":"PAGE_ACCESS_TYPE_PUBLIC","theme":"PAGE_THEME_SYSTEM","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"},"components":[],"groups":[]}`
+		r := io.NopCloser(bytes.NewReader([]byte(body)))
+
+		interceptor := &interceptorHTTPClient{
+			f: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       r,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+				}, nil
+			},
+		}
+
+		err := statuspage.GetStatusPageInfoWithHTTPClient(context.Background(), interceptor.GetHTTPClient(), "test-token", "3")
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("Strips scheme from custom domain", func(t *testing.T) {
+		body := `{"statusPage":{"id":"4","title":"Scheme Page","slug":"scheme","published":true,"customDomain":"https://status.example.com","accessType":"PAGE_ACCESS_TYPE_PUBLIC","theme":"PAGE_THEME_SYSTEM","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"},"components":[],"groups":[]}`
+		r := io.NopCloser(bytes.NewReader([]byte(body)))
+
+		interceptor := &interceptorHTTPClient{
+			f: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       r,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+				}, nil
+			},
+		}
+
+		err := statuspage.GetStatusPageInfoWithHTTPClient(context.Background(), interceptor.GetHTTPClient(), "test-token", "4")
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("Page not found returns actionable error", func(t *testing.T) {
+		body := `{"code":"not_found","message":"status page not found"}`
+		r := io.NopCloser(bytes.NewReader([]byte(body)))
+
+		interceptor := &interceptorHTTPClient{
+			f: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       r,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+				}, nil
+			},
+		}
+
+		err := statuspage.GetStatusPageInfoWithHTTPClient(context.Background(), interceptor.GetHTTPClient(), "test-token", "999")
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+}

--- a/internal/statuspage/statuspage_list.go
+++ b/internal/statuspage/statuspage_list.go
@@ -1,0 +1,113 @@
+package statuspage
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	status_pagev1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_page/v1"
+	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/status_page/v1/status_pagev1connect"
+	"github.com/fatih/color"
+	"github.com/openstatusHQ/cli/internal/auth"
+	output "github.com/openstatusHQ/cli/internal/cli"
+	"github.com/rodaine/table"
+	"github.com/urfave/cli/v3"
+)
+
+type statusPageListEntry struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	URL   string `json:"url"`
+}
+
+func ListStatusPages(ctx context.Context, client status_pagev1connect.StatusPageServiceClient, limit int, s *output.Spinner) error {
+	req := &status_pagev1.ListStatusPagesRequest{}
+
+	if limit > 0 {
+		l := int32(limit)
+		req.SetLimit(l)
+	}
+
+	resp, err := client.ListStatusPages(ctx, req)
+	output.StopSpinner(s)
+	if err != nil {
+		return output.FormatError(err, "status-page", "")
+	}
+
+	pages := resp.GetStatusPages()
+
+	if output.IsJSONOutput() {
+		entries := make([]statusPageListEntry, 0, len(pages))
+		for _, p := range pages {
+			entries = append(entries, statusPageListEntry{
+				ID:    p.GetId(),
+				Title: p.GetTitle(),
+				URL:   "https://" + p.GetSlug() + ".openstatus.dev",
+			})
+		}
+		return output.PrintJSON(entries)
+	}
+
+	if len(pages) == 0 {
+		if !output.IsQuiet() {
+			fmt.Println("No status pages found")
+		}
+		return nil
+	}
+
+	headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
+	columnFmt := color.New(color.FgYellow).SprintfFunc()
+
+	tbl := table.New("ID", "Title", "URL")
+	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
+
+	for _, p := range pages {
+		tbl.AddRow(
+			p.GetId(),
+			p.GetTitle(),
+			"https://"+p.GetSlug()+".openstatus.dev",
+		)
+	}
+
+	tbl.Print()
+	return nil
+}
+
+func ListStatusPagesWithHTTPClient(ctx context.Context, httpClient *http.Client, apiKey string, limit int) error {
+	client := NewStatusPageClientWithHTTPClient(httpClient, apiKey)
+	return ListStatusPages(ctx, client, limit, nil)
+}
+
+func GetStatusPageListCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List all status pages",
+		UsageText: `openstatus status-page list
+  openstatus status-page list --limit 10`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "access-token",
+				Usage:   "OpenStatus API Access Token",
+				Aliases: []string{"t"},
+				Sources: cli.EnvVars("OPENSTATUS_API_TOKEN"),
+			},
+			&cli.IntFlag{
+				Name:  "limit",
+				Usage: "Maximum number of pages to return (1-100)",
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			apiKey, err := auth.ResolveAccessToken(cmd)
+			if err != nil {
+				return cli.Exit(err.Error(), 1)
+			}
+			s := output.StartSpinner("Fetching status pages...")
+			client := NewStatusPageClient(apiKey)
+			err = ListStatusPages(ctx, client, int(cmd.Int("limit")), s)
+			if err != nil {
+				return cli.Exit(err.Error(), 1)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/statuspage/statuspage_list_test.go
+++ b/internal/statuspage/statuspage_list_test.go
@@ -1,0 +1,88 @@
+package statuspage_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/openstatusHQ/cli/internal/statuspage"
+)
+
+func Test_ListStatusPages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Successfully returns pages", func(t *testing.T) {
+		body := `{"statusPages":[{"id":"1","title":"My Status Page","slug":"my-page","published":true,"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"},{"id":"2","title":"Internal Page","slug":"internal","published":false,"createdAt":"2026-02-01T00:00:00Z","updatedAt":"2026-02-01T00:00:00Z"}],"totalSize":2}`
+		r := io.NopCloser(bytes.NewReader([]byte(body)))
+
+		interceptor := &interceptorHTTPClient{
+			f: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       r,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+				}, nil
+			},
+		}
+
+		var bf bytes.Buffer
+		log.SetOutput(&bf)
+		t.Cleanup(func() {
+			log.SetOutput(os.Stderr)
+		})
+		err := statuspage.ListStatusPagesWithHTTPClient(context.Background(), interceptor.GetHTTPClient(), "test-token", 0)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("Returns empty list", func(t *testing.T) {
+		body := `{"statusPages":[],"totalSize":0}`
+		r := io.NopCloser(bytes.NewReader([]byte(body)))
+
+		interceptor := &interceptorHTTPClient{
+			f: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       r,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+				}, nil
+			},
+		}
+
+		err := statuspage.ListStatusPagesWithHTTPClient(context.Background(), interceptor.GetHTTPClient(), "test-token", 0)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		body := `{"code":"internal","message":"internal error"}`
+		r := io.NopCloser(bytes.NewReader([]byte(body)))
+
+		interceptor := &interceptorHTTPClient{
+			f: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       r,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+				}, nil
+			},
+		}
+
+		err := statuspage.ListStatusPagesWithHTTPClient(context.Background(), interceptor.GetHTTPClient(), "test-token", 0)
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+}

--- a/internal/statuspage/statuspage_test.go
+++ b/internal/statuspage/statuspage_test.go
@@ -1,0 +1,82 @@
+package statuspage_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/openstatusHQ/cli/internal/statuspage"
+)
+
+type interceptorHTTPClient struct {
+	f func(req *http.Request) (*http.Response, error)
+}
+
+func (i *interceptorHTTPClient) RoundTrip(req *http.Request) (*http.Response, error) {
+	return i.f(req)
+}
+
+func (i *interceptorHTTPClient) GetHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: i,
+	}
+}
+
+func Test_StatusPageCmd(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Returns valid command", func(t *testing.T) {
+		cmd := statuspage.StatusPageCmd()
+
+		if cmd == nil {
+			t.Fatal("Expected non-nil command")
+		}
+
+		if cmd.Name != "status-page" {
+			t.Errorf("Expected command name 'status-page', got %s", cmd.Name)
+		}
+
+		if cmd.Usage != "Manage status pages" {
+			t.Errorf("Expected usage 'Manage status pages', got %s", cmd.Usage)
+		}
+	})
+
+	t.Run("Has expected subcommands", func(t *testing.T) {
+		cmd := statuspage.StatusPageCmd()
+
+		if len(cmd.Commands) != 2 {
+			t.Errorf("Expected 2 subcommands, got %d", len(cmd.Commands))
+		}
+
+		expectedSubcommands := map[string]bool{
+			"list": false,
+			"info": false,
+		}
+
+		for _, subcmd := range cmd.Commands {
+			if _, exists := expectedSubcommands[subcmd.Name]; exists {
+				expectedSubcommands[subcmd.Name] = true
+			}
+		}
+
+		for name, found := range expectedSubcommands {
+			if !found {
+				t.Errorf("Expected subcommand '%s' not found", name)
+			}
+		}
+	})
+
+	t.Run("Has sp alias", func(t *testing.T) {
+		cmd := statuspage.StatusPageCmd()
+
+		found := false
+		for _, alias := range cmd.Aliases {
+			if alias == "sp" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("Expected 'sp' alias not found")
+		}
+	})
+}


### PR DESCRIPTION
Add a new `status-page` (alias `sp`) command group with two subcommands:
- `list`: displays all status pages with ID, title, and URL
- `info <page-id>`: shows page details and attached components grouped by component group, using the GetStatusPageContent RPC

URL resolves to custom domain when available, otherwise slug.openstatus.dev.