### PR TITLE
chore(lint): add golangci-lint v2 with CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,100 @@
+version: "2"
+
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+
+linters:
+  default: standard
+  enable:
+    - bodyclose
+    - copyloopvar
+    - errorlint
+    - gocritic
+    - gosec
+    - misspell
+    - nolintlint
+    - revive
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - whitespace
+
+  settings:
+    errcheck:
+      exclude-functions:
+        - (*github.com/olekukonko/tablewriter.Table).Bulk
+        - (*github.com/olekukonko/tablewriter.Table).Render
+        - (*os/exec.Cmd).Wait
+        - github.com/joho/godotenv.Load
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - performance
+        - style
+      disabled-checks:
+        - appendCombine
+        - commentedOutCode
+        - hugeParam
+        - ifElseChain
+        - importShadow
+        - paramTypeCombine
+        - rangeValCopy
+        - unlambda # test seams use this pattern
+        - unnamedResult
+    gosec:
+      excludes:
+        - G104 # duplicated by errcheck
+        - G115 # int->int32 narrowing for proto/API fields is intentional
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: increment-decrement
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+          disabled: true # CLI internals return unexported result types
+        - name: unreachable-code
+        - name: unused-parameter
+          disabled: true
+        - name: var-naming
+          disabled: true # conflicts with generated proto identifiers (Id, Url, …)
+
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+          - gocritic
+          - gosec
+          - unparam
+      - path: internal/cli/pager\.go
+        linters:
+          - gosec # G204: PAGER env var is the standard CLI pattern
+      # int(cmd.Int(...)) idiom from urfave/cli/v3 and int64() casts of proto ints
+      - linters:
+          - unconvert
+        text: unnecessary conversion
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/openstatusHQ/cli

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -3,8 +3,9 @@ package main
 import (
 	"os"
 
-	cmd "github.com/openstatusHQ/cli/internal/cmd"
 	docs "github.com/urfave/cli-docs/v3"
+
+	cmd "github.com/openstatusHQ/cli/internal/cmd"
 )
 
 func main() {

--- a/cmd/openstatus/main.go
+++ b/cmd/openstatus/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
-	"github.com/joho/godotenv"
-	cmd "github.com/openstatusHQ/cli/internal/cmd"
 	"log"
+
+	"github.com/joho/godotenv"
+
+	cmd "github.com/openstatusHQ/cli/internal/cmd"
 )
 
 func main() {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+
 	output "github.com/openstatusHQ/cli/internal/cli"
 )
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/openstatusHQ/cli/internal/config"
 	clilib "github.com/urfave/cli/v3"
+
+	"github.com/openstatusHQ/cli/internal/config"
 )
 
 // ResolveAccessToken extracts the access token from CLI flags or falls back to saved token.
@@ -40,7 +41,7 @@ func SaveToken(token string) error {
 	if err != nil {
 		return fmt.Errorf("failed to determine config directory: %w", err)
 	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
@@ -64,7 +65,7 @@ func SaveToken(token string) error {
 		os.Remove(tmpPath)
 		return fmt.Errorf("failed to close temp file: %w", err)
 	}
-	if err := os.Chmod(tmpPath, 0600); err != nil {
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
 		os.Remove(tmpPath)
 		return fmt.Errorf("failed to set token file permissions: %w", err)
 	}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -26,9 +26,11 @@ func IsDebug() bool        { return debugMode.Load() }
 func IsTerminal() bool {
 	return isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 }
+
 func IsStdinTerminal() bool {
 	return isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())
 }
+
 func IsStderrTerminal() bool {
 	return isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd())
 }

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -6,6 +6,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/urfave/cli/v3"
+
 	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/openstatusHQ/cli/internal/login"
 	"github.com/openstatusHQ/cli/internal/maintenance"
@@ -16,7 +18,6 @@ import (
 	"github.com/openstatusHQ/cli/internal/statusreport"
 	"github.com/openstatusHQ/cli/internal/terraform"
 	"github.com/openstatusHQ/cli/internal/whoami"
-	"github.com/urfave/cli/v3"
 )
 
 func NewApp() *cli.Command {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/openstatusHQ/cli/internal/config"
 )
 
@@ -24,7 +25,7 @@ func Test_ReadConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err := f.Write([]byte(configFile)); err != nil {
+		if _, err := f.WriteString(configFile); err != nil {
 			t.Fatal(err)
 		}
 		if err := f.Close(); err != nil {
@@ -60,7 +61,7 @@ func Test_ReadConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err := f.Write([]byte("invalid: yaml: content: [")); err != nil {
+		if _, err := f.WriteString("invalid: yaml: content: ["); err != nil {
 			t.Fatal(err)
 		}
 		if err := f.Close(); err != nil {
@@ -78,12 +79,12 @@ func Test_ReadConfig_NoStatePollution(t *testing.T) {
 	dir := t.TempDir()
 
 	file1 := filepath.Join(dir, "config1.yaml")
-	if err := os.WriteFile(file1, []byte("tests:\n  ids:\n    - 1\n    - 2\n    - 3\n"), 0600); err != nil {
+	if err := os.WriteFile(file1, []byte("tests:\n  ids:\n    - 1\n    - 2\n    - 3\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
 	file2 := filepath.Join(dir, "config2.yaml")
-	if err := os.WriteFile(file2, []byte("tests:\n  ids:\n    - 4\n    - 5\n    - 6\n"), 0600); err != nil {
+	if err := os.WriteFile(file2, []byte("tests:\n  ids:\n    - 4\n    - 5\n    - 6\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/config/lock.go
+++ b/internal/config/lock.go
@@ -17,17 +17,15 @@ type Lock struct {
 type MonitorsLock map[string]Lock
 
 func ReadLockFile(filename string) (MonitorsLock, error) {
-
 	var out MonitorsLock
 	if _, err := os.Stat(filename); errors.Is(err, os.ErrNotExist) {
 		return MonitorsLock{}, nil
 	}
 
 	file := file.Provider(filename)
-	var k = koanf.New(".")
+	k := koanf.New(".")
 
 	err := k.Load(file, yaml.Parser())
-
 	if err != nil {
 		return nil, err
 	}
@@ -41,5 +39,4 @@ func ReadLockFile(filename string) (MonitorsLock, error) {
 	}
 
 	return out, nil
-
 }

--- a/internal/config/lock_test.go
+++ b/internal/config/lock_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/openstatusHQ/cli/internal/config"
 )
 
@@ -43,7 +44,7 @@ func Test_getMonitorTrigger(t *testing.T) {
 		}
 		defer os.Remove(f.Name()) // clean up
 
-		if _, err := f.Write([]byte(lockfile)); err != nil {
+		if _, err := f.WriteString(lockfile); err != nil {
 			t.Fatal(err)
 		}
 		if err := f.Close(); err != nil {
@@ -89,7 +90,6 @@ func Test_getMonitorTrigger(t *testing.T) {
 	})
 
 	t.Run("No Lock file", func(t *testing.T) {
-
 		out, err := config.ReadLockFile("doesnotexist")
 		if err != nil {
 			t.Fatal(err)

--- a/internal/config/monitor_test.go
+++ b/internal/config/monitor_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/openstatusHQ/cli/internal/config"
 )
 

--- a/internal/config/openstatus_test.go
+++ b/internal/config/openstatus_test.go
@@ -37,7 +37,7 @@ func Test_ReadOpenStatus(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err := f.Write([]byte(openstatusConfig)); err != nil {
+		if _, err := f.WriteString(openstatusConfig); err != nil {
 			t.Fatal(err)
 		}
 		if err := f.Close(); err != nil {
@@ -114,7 +114,7 @@ func Test_ReadOpenStatus_FollowRedirects(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err := f.Write([]byte(yaml)); err != nil {
+		if _, err := f.WriteString(yaml); err != nil {
 			t.Fatal(err)
 		}
 		if err := f.Close(); err != nil {
@@ -157,7 +157,7 @@ func Test_ReadOpenStatus_FollowRedirects(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err := f.Write([]byte(yaml)); err != nil {
+		if _, err := f.WriteString(yaml); err != nil {
 			t.Fatal(err)
 		}
 		if err := f.Close(); err != nil {
@@ -272,7 +272,7 @@ func Test_ReadOpenStatus_NoStatePollution(t *testing.T) {
   request:
     method: GET
     url: https://a.example.com
-`), 0600); err != nil {
+`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -288,7 +288,7 @@ func Test_ReadOpenStatus_NoStatePollution(t *testing.T) {
   request:
     method: POST
     url: https://b.example.com
-`), 0600); err != nil {
+`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -7,11 +7,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/urfave/cli/v3"
+	"golang.org/x/term"
+
 	"github.com/openstatusHQ/cli/internal/api"
 	"github.com/openstatusHQ/cli/internal/auth"
 	"github.com/openstatusHQ/cli/internal/whoami"
-	"github.com/urfave/cli/v3"
-	"golang.org/x/term"
 )
 
 func LoginCmd() *cli.Command {

--- a/internal/maintenance/maintenance.go
+++ b/internal/maintenance/maintenance.go
@@ -7,8 +7,9 @@ import (
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/maintenance/v1/maintenancev1connect"
 	"connectrpc.com/connect"
 	"github.com/fatih/color"
-	"github.com/openstatusHQ/cli/internal/api"
 	"github.com/urfave/cli/v3"
+
+	"github.com/openstatusHQ/cli/internal/api"
 )
 
 func NewMaintenanceClient(apiKey string) maintenancev1connect.MaintenanceServiceClient {

--- a/internal/maintenance/maintenance_create.go
+++ b/internal/maintenance/maintenance_create.go
@@ -8,9 +8,10 @@ import (
 
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/maintenance/v1/maintenancev1connect"
 	maintenancev1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/maintenance/v1"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 func CreateMaintenance(ctx context.Context, client maintenancev1connect.MaintenanceServiceClient, title, message, from, to, pageId string, componentIds []string, notify bool) (string, error) {

--- a/internal/maintenance/maintenance_delete.go
+++ b/internal/maintenance/maintenance_delete.go
@@ -8,9 +8,10 @@ import (
 
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/maintenance/v1/maintenancev1connect"
 	maintenancev1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/maintenance/v1"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 func DeleteMaintenance(ctx context.Context, client maintenancev1connect.MaintenanceServiceClient, maintenanceId string) error {

--- a/internal/maintenance/maintenance_info.go
+++ b/internal/maintenance/maintenance_info.go
@@ -13,9 +13,10 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 type maintenanceDetail struct {

--- a/internal/maintenance/maintenance_list.go
+++ b/internal/maintenance/maintenance_list.go
@@ -8,10 +8,11 @@ import (
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/maintenance/v1/maintenancev1connect"
 	maintenancev1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/maintenance/v1"
 	"github.com/fatih/color"
-	"github.com/openstatusHQ/cli/internal/auth"
-	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/rodaine/table"
 	"github.com/urfave/cli/v3"
+
+	"github.com/openstatusHQ/cli/internal/auth"
+	output "github.com/openstatusHQ/cli/internal/cli"
 )
 
 type maintenanceListEntry struct {

--- a/internal/maintenance/maintenance_update.go
+++ b/internal/maintenance/maintenance_update.go
@@ -9,9 +9,10 @@ import (
 
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/maintenance/v1/maintenancev1connect"
 	maintenancev1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/maintenance/v1"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 func UpdateMaintenance(ctx context.Context, client maintenancev1connect.MaintenanceServiceClient, id, title, message, from, to string, componentIds []string, hasTitle, hasMessage, hasFrom, hasTo, hasComponents bool) error {

--- a/internal/maintenance/maintenance_wizard.go
+++ b/internal/maintenance/maintenance_wizard.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/huh"
+
 	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/openstatusHQ/cli/internal/statuspage"
 	"github.com/openstatusHQ/cli/internal/wizard"

--- a/internal/monitors/export_test.go
+++ b/internal/monitors/export_test.go
@@ -1,5 +1,7 @@
 package monitors
 
-var RegionToString = regionToString
-var StringToRegion = stringToRegion
-var ConfigToTCPMonitor = configToTCPMonitor
+var (
+	RegionToString     = regionToString
+	StringToRegion     = stringToRegion
+	ConfigToTCPMonitor = configToTCPMonitor
+)

--- a/internal/monitors/monitor_apply.go
+++ b/internal/monitors/monitor_apply.go
@@ -7,12 +7,13 @@ import (
 	"os"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/urfave/cli/v3"
+	"sigs.k8s.io/yaml"
+
 	"github.com/openstatusHQ/cli/internal/api"
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/openstatusHQ/cli/internal/config"
-	"github.com/urfave/cli/v3"
-	"sigs.k8s.io/yaml"
 )
 
 // countChanges computes the number of creates, updates, and deletes without making API calls.
@@ -206,7 +207,7 @@ Compares your openstatus.yaml with the current state and applies changes.`,
 			if err != nil {
 				return cli.Exit("Failed to marshal lock file", 1)
 			}
-			file, err := os.OpenFile("openstatus.lock", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+			file, err := os.OpenFile("openstatus.lock", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 			if err != nil {
 				return cli.Exit("Failed to open lock file", 1)
 			}

--- a/internal/monitors/monitor_create.go
+++ b/internal/monitors/monitor_create.go
@@ -10,11 +10,12 @@ import (
 
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/monitor/v1/monitorv1connect"
 	monitorv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/monitor/v1"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/api"
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/openstatusHQ/cli/internal/config"
-	"github.com/urfave/cli/v3"
 )
 
 // CreateMonitor creates a monitor using the SDK, dispatching to the appropriate type

--- a/internal/monitors/monitor_create_test.go
+++ b/internal/monitors/monitor_create_test.go
@@ -169,7 +169,7 @@ func Test_CreateMonitor(t *testing.T) {
 		if result.Periodicity != "5m" {
 			t.Errorf("Expected periodicity '5m', got %s", result.Periodicity)
 		}
-		if result.Method != "POST" {
+		if result.Method != http.MethodPost {
 			t.Errorf("Expected method 'POST', got %s", result.Method)
 		}
 		if result.Active != true {

--- a/internal/monitors/monitor_delete.go
+++ b/internal/monitors/monitor_delete.go
@@ -8,9 +8,10 @@ import (
 
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/monitor/v1/monitorv1connect"
 	monitorv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/monitor/v1"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 // DeleteMonitor deletes a monitor using the SDK

--- a/internal/monitors/monitor_import.go
+++ b/internal/monitors/monitor_import.go
@@ -10,11 +10,12 @@ import (
 
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/monitor/v1/monitorv1connect"
 	monitorv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/monitor/v1"
+	"github.com/urfave/cli/v3"
+	"sigs.k8s.io/yaml"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/openstatusHQ/cli/internal/config"
-	"github.com/urfave/cli/v3"
-	"sigs.k8s.io/yaml"
 )
 
 // ExportMonitor exports all monitors to a YAML file using the SDK
@@ -56,7 +57,7 @@ func ExportMonitor(ctx context.Context, client monitorv1connect.MonitorServiceCl
 		return fmt.Errorf("failed to marshal lock file: %w", err)
 	}
 
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -69,7 +70,7 @@ func ExportMonitor(ctx context.Context, client monitorv1connect.MonitorServiceCl
 		return err
 	}
 
-	lockFile, err := os.OpenFile("openstatus.lock", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	lockFile, err := os.OpenFile("openstatus.lock", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create lock file: %w", err)
 	}

--- a/internal/monitors/monitor_info.go
+++ b/internal/monitors/monitor_info.go
@@ -14,10 +14,11 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/api"
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 type MonitorInfoOutput struct {
@@ -167,7 +168,6 @@ func newBlueprintTable() *tablewriter.Table {
 }
 
 func GetMonitorInfo(ctx context.Context, httpClient *http.Client, apiKey string, monitorId string, timeRange monitorv1.TimeRange, timeRangeStr string, s *output.Spinner) error {
-
 	if monitorId == "" {
 		output.StopSpinner(s)
 		fmt.Fprintln(os.Stderr, "Usage: openstatus monitors info <monitor-id>")

--- a/internal/monitors/monitor_info_test.go
+++ b/internal/monitors/monitor_info_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	monitorv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/monitor/v1"
+
 	"github.com/openstatusHQ/cli/internal/monitors"
 )
 

--- a/internal/monitors/monitor_log_info.go
+++ b/internal/monitors/monitor_log_info.go
@@ -13,9 +13,10 @@ import (
 	monitorv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/monitor/v1"
 	"github.com/fatih/color"
 	"github.com/logrusorgru/aurora/v4"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 type responseLogDetailOutput struct {

--- a/internal/monitors/monitor_logs.go
+++ b/internal/monitors/monitor_logs.go
@@ -10,10 +10,11 @@ import (
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/monitor/v1/monitorv1connect"
 	monitorv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/monitor/v1"
 	"github.com/fatih/color"
-	"github.com/openstatusHQ/cli/internal/auth"
-	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/rodaine/table"
 	"github.com/urfave/cli/v3"
+
+	"github.com/openstatusHQ/cli/internal/auth"
+	output "github.com/openstatusHQ/cli/internal/cli"
 )
 
 type responseLogEntry struct {

--- a/internal/monitors/monitor_trigger.go
+++ b/internal/monitors/monitor_trigger.go
@@ -8,9 +8,10 @@ import (
 
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/monitor/v1/monitorv1connect"
 	monitorv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/monitor/v1"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 // TriggerMonitor triggers a monitor using the SDK

--- a/internal/monitors/monitor_update.go
+++ b/internal/monitors/monitor_update.go
@@ -8,6 +8,7 @@ import (
 
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/monitor/v1/monitorv1connect"
 	monitorv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/monitor/v1"
+
 	"github.com/openstatusHQ/cli/internal/config"
 )
 

--- a/internal/monitors/monitor_update_test.go
+++ b/internal/monitors/monitor_update_test.go
@@ -182,7 +182,7 @@ func Test_UpdateMonitor(t *testing.T) {
 		if result.Periodicity != "5m" {
 			t.Errorf("Expected periodicity '5m', got %s", result.Periodicity)
 		}
-		if result.Method != "POST" {
+		if result.Method != http.MethodPost {
 			t.Errorf("Expected method 'POST', got %s", result.Method)
 		}
 		if result.Active != true {

--- a/internal/monitors/monitors.go
+++ b/internal/monitors/monitors.go
@@ -9,9 +9,10 @@ import (
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/monitor/v1/monitorv1connect"
 	monitorv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/monitor/v1"
 	"connectrpc.com/connect"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/api"
 	"github.com/openstatusHQ/cli/internal/config"
-	"github.com/urfave/cli/v3"
 )
 
 func NewMonitorClient(apiKey string) monitorv1connect.MonitorServiceClient {

--- a/internal/monitors/monitors_list.go
+++ b/internal/monitors/monitors_list.go
@@ -8,10 +8,11 @@ import (
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/monitor/v1/monitorv1connect"
 	monitorv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/monitor/v1"
 	"github.com/fatih/color"
-	"github.com/openstatusHQ/cli/internal/auth"
-	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/rodaine/table"
 	"github.com/urfave/cli/v3"
+
+	"github.com/openstatusHQ/cli/internal/auth"
+	output "github.com/openstatusHQ/cli/internal/cli"
 )
 
 type monitorListEntry struct {

--- a/internal/monitors/monitors_region_test.go
+++ b/internal/monitors/monitors_region_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	monitorv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/monitor/v1"
+
 	"github.com/openstatusHQ/cli/internal/config"
 	"github.com/openstatusHQ/cli/internal/monitors"
 )

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -6,8 +6,9 @@ import (
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/notification/v1/notificationv1connect"
 	notificationv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/notification/v1"
 	"connectrpc.com/connect"
-	"github.com/openstatusHQ/cli/internal/api"
 	"github.com/urfave/cli/v3"
+
+	"github.com/openstatusHQ/cli/internal/api"
 )
 
 func NewNotificationClient(apiKey string) notificationv1connect.NotificationServiceClient {

--- a/internal/notification/notification_info.go
+++ b/internal/notification/notification_info.go
@@ -13,9 +13,10 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 type notificationDetail struct {

--- a/internal/notification/notification_list.go
+++ b/internal/notification/notification_list.go
@@ -8,10 +8,11 @@ import (
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/notification/v1/notificationv1connect"
 	notificationv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/notification/v1"
 	"github.com/fatih/color"
-	"github.com/openstatusHQ/cli/internal/auth"
-	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/rodaine/table"
 	"github.com/urfave/cli/v3"
+
+	"github.com/openstatusHQ/cli/internal/auth"
+	output "github.com/openstatusHQ/cli/internal/cli"
 )
 
 type notificationListEntry struct {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -14,13 +14,14 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/logrusorgru/aurora/v4"
+	"github.com/rodaine/table"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/api"
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/openstatusHQ/cli/internal/config"
 	"github.com/openstatusHQ/cli/internal/monitors"
-	"github.com/rodaine/table"
-	"github.com/urfave/cli/v3"
 )
 
 type runRegionResult struct {
@@ -37,7 +38,6 @@ type runMonitorResult struct {
 
 // MonitorTrigger triggers a monitor run and returns the results without printing.
 func MonitorTrigger(ctx context.Context, httpClient *http.Client, apiKey string, monitorId string) (runMonitorResult, error) {
-
 	if monitorId == "" {
 		return runMonitorResult{}, fmt.Errorf("monitor ID is required")
 	}
@@ -51,7 +51,7 @@ func MonitorTrigger(ctx context.Context, httpClient *http.Client, apiKey string,
 
 	payload := strings.NewReader("{}")
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, payload)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, payload)
 	if err != nil {
 		return runMonitorResult{}, err
 	}

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -57,7 +57,7 @@ func Test_run(t *testing.T) {
 			t.Errorf("Monitor Trigger should return error")
 		}
 	})
-	t.Run("Successfully run http reponse", func(t *testing.T) {
+	t.Run("Successfully run http response", func(t *testing.T) {
 		body := `[
   {
   "jobType": "http",
@@ -101,7 +101,7 @@ func Test_run(t *testing.T) {
 			t.Errorf("Monitor Trigger should return error")
 		}
 	})
-	t.Run("Successfully run tcp reponse", func(t *testing.T) {
+	t.Run("Successfully run tcp response", func(t *testing.T) {
 		body := `[
 		{
     "jobType": "tcp",

--- a/internal/statuspage/statuspage.go
+++ b/internal/statuspage/statuspage.go
@@ -6,8 +6,9 @@ import (
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/status_page/v1/status_pagev1connect"
 	status_pagev1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_page/v1"
 	"connectrpc.com/connect"
-	"github.com/openstatusHQ/cli/internal/api"
 	"github.com/urfave/cli/v3"
+
+	"github.com/openstatusHQ/cli/internal/api"
 )
 
 func NewStatusPageClient(apiKey string) status_pagev1connect.StatusPageServiceClient {

--- a/internal/statuspage/statuspage_info.go
+++ b/internal/statuspage/statuspage_info.go
@@ -16,10 +16,11 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
-	"github.com/openstatusHQ/cli/internal/auth"
-	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/rodaine/table"
 	"github.com/urfave/cli/v3"
+
+	"github.com/openstatusHQ/cli/internal/auth"
+	output "github.com/openstatusHQ/cli/internal/cli"
 )
 
 type statusPageDetail struct {

--- a/internal/statuspage/statuspage_list.go
+++ b/internal/statuspage/statuspage_list.go
@@ -9,10 +9,11 @@ import (
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/status_page/v1/status_pagev1connect"
 	status_pagev1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_page/v1"
 	"github.com/fatih/color"
-	"github.com/openstatusHQ/cli/internal/auth"
-	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/rodaine/table"
 	"github.com/urfave/cli/v3"
+
+	"github.com/openstatusHQ/cli/internal/auth"
+	output "github.com/openstatusHQ/cli/internal/cli"
 )
 
 type statusPageListEntry struct {

--- a/internal/statusreport/statusreport.go
+++ b/internal/statusreport/statusreport.go
@@ -8,8 +8,9 @@ import (
 	status_reportv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_report/v1"
 	"connectrpc.com/connect"
 	"github.com/fatih/color"
-	"github.com/openstatusHQ/cli/internal/api"
 	"github.com/urfave/cli/v3"
+
+	"github.com/openstatusHQ/cli/internal/api"
 )
 
 func NewStatusReportClient(apiKey string) status_reportv1connect.StatusReportServiceClient {

--- a/internal/statusreport/statusreport_add_update.go
+++ b/internal/statusreport/statusreport_add_update.go
@@ -10,9 +10,10 @@ import (
 
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/status_report/v1/status_reportv1connect"
 	status_reportv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_report/v1"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 func AddStatusReportUpdate(ctx context.Context, client status_reportv1connect.StatusReportServiceClient, reportId, status, message, date string, notify bool, s *output.Spinner) error {

--- a/internal/statusreport/statusreport_create.go
+++ b/internal/statusreport/statusreport_create.go
@@ -9,9 +9,10 @@ import (
 
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/status_report/v1/status_reportv1connect"
 	status_reportv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_report/v1"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 func CreateStatusReport(ctx context.Context, client status_reportv1connect.StatusReportServiceClient, title, status, message, date, pageId string, componentIds []string, notify bool) (string, error) {

--- a/internal/statusreport/statusreport_delete.go
+++ b/internal/statusreport/statusreport_delete.go
@@ -8,9 +8,10 @@ import (
 
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/status_report/v1/status_reportv1connect"
 	status_reportv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_report/v1"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 func DeleteStatusReport(ctx context.Context, client status_reportv1connect.StatusReportServiceClient, reportId string) error {

--- a/internal/statusreport/statusreport_info.go
+++ b/internal/statusreport/statusreport_info.go
@@ -13,9 +13,10 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 type statusReportDetail struct {

--- a/internal/statusreport/statusreport_list.go
+++ b/internal/statusreport/statusreport_list.go
@@ -8,10 +8,11 @@ import (
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/status_report/v1/status_reportv1connect"
 	status_reportv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_report/v1"
 	"github.com/fatih/color"
-	"github.com/openstatusHQ/cli/internal/auth"
-	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/rodaine/table"
 	"github.com/urfave/cli/v3"
+
+	"github.com/openstatusHQ/cli/internal/auth"
+	output "github.com/openstatusHQ/cli/internal/cli"
 )
 
 type statusReportListEntry struct {

--- a/internal/statusreport/statusreport_update.go
+++ b/internal/statusreport/statusreport_update.go
@@ -9,9 +9,10 @@ import (
 
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/status_report/v1/status_reportv1connect"
 	status_reportv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_report/v1"
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 func UpdateStatusReport(ctx context.Context, client status_reportv1connect.StatusReportServiceClient, reportId string, title string, componentIds []string, hasTitle bool, hasComponents bool) error {

--- a/internal/statusreport/statusreport_wizard.go
+++ b/internal/statusreport/statusreport_wizard.go
@@ -8,6 +8,7 @@ import (
 
 	status_reportv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_report/v1"
 	"github.com/charmbracelet/huh"
+
 	output "github.com/openstatusHQ/cli/internal/cli"
 	"github.com/openstatusHQ/cli/internal/statuspage"
 	"github.com/openstatusHQ/cli/internal/wizard"

--- a/internal/terraform/cli_test.go
+++ b/internal/terraform/cli_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCheckExistingFiles_RefusesExisting(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "monitors.tf"), []byte("existing"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "monitors.tf"), []byte("existing"), 0o644); err != nil {
 		t.Fatalf("seeding fixture: %v", err)
 	}
 
@@ -28,7 +28,7 @@ func TestCheckExistingFiles_RefusesExisting(t *testing.T) {
 
 func TestCheckExistingFiles_OverwritesWithForce(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "monitors.tf"), []byte("existing"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "monitors.tf"), []byte("existing"), 0o644); err != nil {
 		t.Fatalf("seeding fixture: %v", err)
 	}
 

--- a/internal/terraform/fetch.go
+++ b/internal/terraform/fetch.go
@@ -11,6 +11,7 @@ import (
 	notificationv1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/notification/v1"
 	status_pagev1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_page/v1"
 	"connectrpc.com/connect"
+
 	"github.com/openstatusHQ/cli/internal/api"
 )
 

--- a/internal/terraform/generate.go
+++ b/internal/terraform/generate.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 var generatedFileNames = []string{
@@ -54,7 +55,7 @@ func GetTerraformGenerateCmd() *cli.Command {
 			if err := checkExistingFiles(outputDir, cmd.Bool("force")); err != nil {
 				return cli.Exit(err.Error(), 1)
 			}
-			if err := os.MkdirAll(outputDir, 0755); err != nil {
+			if err := os.MkdirAll(outputDir, 0o755); err != nil {
 				return cli.Exit(fmt.Sprintf("failed to create output directory: %v", err), 1)
 			}
 
@@ -118,7 +119,7 @@ func checkExistingFiles(outputDir string, force bool) error {
 }
 
 func writeFile(path string, content []byte) error {
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}

--- a/internal/terraform/naming.go
+++ b/internal/terraform/naming.go
@@ -9,8 +9,10 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-var nonAlphanumRegexp = regexp.MustCompile(`[^a-z0-9]+`)
-var multiUnderscoreRegexp = regexp.MustCompile(`_+`)
+var (
+	nonAlphanumRegexp     = regexp.MustCompile(`[^a-z0-9]+`)
+	multiUnderscoreRegexp = regexp.MustCompile(`_+`)
+)
 
 func sanitizeName(name string) string {
 	name = strings.TrimSpace(name)

--- a/internal/whoami/whoami.go
+++ b/internal/whoami/whoami.go
@@ -7,10 +7,11 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/urfave/cli/v3"
+
 	"github.com/openstatusHQ/cli/internal/api"
 	"github.com/openstatusHQ/cli/internal/auth"
 	output "github.com/openstatusHQ/cli/internal/cli"
-	"github.com/urfave/cli/v3"
 )
 
 type Whoami struct {
@@ -22,7 +23,7 @@ type Whoami struct {
 func GetWhoamiCmd(ctx context.Context, httpClient *http.Client, apiKey string, s *output.Spinner) error {
 	url := fmt.Sprintf("%s/whoami", api.APIBaseURL)
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -87,7 +88,8 @@ Displays the workspace name, slug, and plan.`,
 				Usage:   "OpenStatus API Access Token",
 				Aliases: []string{"t"},
 				Sources: cli.EnvVars("OPENSTATUS_API_TOKEN"),
-			}},
+			},
+		},
 	}
 	return &whoamiCmd
 }

--- a/internal/whoami/whoami_test.go
+++ b/internal/whoami/whoami_test.go
@@ -59,7 +59,6 @@ func Test_getWhoami(t *testing.T) {
 	})
 
 	t.Run("Should return error", func(t *testing.T) {
-
 		interceptor := &interceptorHTTPClient{
 			f: func(req *http.Request) (*http.Response, error) {
 				return &http.Response{

--- a/internal/wizard/statuspage.go
+++ b/internal/wizard/statuspage.go
@@ -6,6 +6,7 @@ import (
 	"buf.build/gen/go/openstatus/api/connectrpc/gosimple/openstatus/status_page/v1/status_pagev1connect"
 	status_pagev1 "buf.build/gen/go/openstatus/api/protocolbuffers/go/openstatus/status_page/v1"
 	"connectrpc.com/connect"
+
 	"github.com/openstatusHQ/cli/internal/api"
 	output "github.com/openstatusHQ/cli/internal/cli"
 )

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -29,7 +29,7 @@ func HandleFormError(err error) error {
 func BuildSummary(lines [][2]string) string {
 	var sb strings.Builder
 	for _, line := range lines {
-		sb.WriteString(fmt.Sprintf("  %s: %s\n", line[0], line[1]))
+		fmt.Fprintf(&sb, "  %s: %s\n", line[0], line[1])
 	}
 	return sb.String()
 }


### PR DESCRIPTION
Configure golangci-lint v2.12.2 with a curated linter set (bodyclose, errorlint, gocritic, gosec, revive, etc.) plus gofumpt + goimports formatters. Add a GitHub Actions workflow that runs lint on push and PR.

Tune rule suppressions for CLI idioms (tablewriter result discard, PAGER subprocess, urfave/cli int casts, proto Id/Url naming). Apply golangci-lint --fix across 59 files for whitespace, gofumpt, and staticcheck rewrites; tests still pass.